### PR TITLE
Android: temp fix loop restarts

### DIFF
--- a/src/android/plugin/src/main/java/plugin/liveBuild/SyncTask.java
+++ b/src/android/plugin/src/main/java/plugin/liveBuild/SyncTask.java
@@ -779,6 +779,11 @@ class SyncTask extends TimerTask {
             linksToCreate = 0;
         }
 
+        // TODO: Consider parsing the compressed resource.car directly from the apk to remove this
+        //       exception. The Android part of Solar2D uses mmap to load the unzipped resource.car,
+        //       whose location overlaps with mBaseDir, causing the update to be triggered.
+        filesToDelete.remove("/resource.car");
+
         int numUpdates = filesToDelete.size() + filesToDownload.size() + dirsToCreate.size() + dirsToDelete.size() + linksToCreate;
 
         if (numUpdates > 0) {


### PR DESCRIPTION
After https://github.com/coronalabs/corona/commit/aa4140d029f2ca29326dd2503fe3a421cd2b757c, the copied resource.car was overlap with live build baseDir, cause app keep restarts.

This is minimum change to fix app restarts after 3705, it is simple but also not affect the performance before 3705, which resource.car would not have been created and being ignored is just “redundant”.

See:
1. https://forums.solar2d.com/t/live-build-the-issue-with-cycle-synchronization-in-android-app/356752
2. https://github.com/coronalabs/corona/issues/689